### PR TITLE
Checking out actual *.h5 files requires Git LFS

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Pretrained models for the ANN-based post-correction component.
 
+## Installation
+
+To checkout the models, [`Git LFS` must be installed](https://github.com/git-lfs/git-lfs/releases).
+
 ## Models
 
 ### OCR post-correction


### PR DESCRIPTION
It seems that depending on the version of git, not having `git-lfs` installed will not consistently raise an error. For my git 2.1.4 this leads to an error on checkout, but not for 2.17.1.  Users can end up with a seemingly successful checkout of the repo but only have the pointer files. This leads to runtime errors when instead of the binary model files, the textual pointer files are loaded.

I guess I didn't notice this before because I had git-lfs installed and so does CircleCI (otherwise ocrd_all should have failed to build).
